### PR TITLE
fixed config

### DIFF
--- a/config/main.cue
+++ b/config/main.cue
@@ -10,29 +10,19 @@ env: {
 	assets: bl.Directory
 }
 
-
-#TestApp: {
-	frameworkName: string
-
-	#PythonApp & {
-		source: bl.Directory & {
-			source: env.assets
-			path: frameworkName
-		}
-	}
-}
-
-
 #TestAppGrid: {
-	pythonVersions : [version=string]: true
+	pythonVersions : [string]: true
 
-	frameworkNames : [name=string]: true
+	frameworkNames : [string]: true
 
-	apps: [name=string]: [version=string]: #TestApp
+	apps: [string]: [string]: #PythonApp
 	for frameworkName, _ in frameworkNames {
 		for pythonVersion, _ in pythonVersions {
-			apps: "\(frameworkName)": "\(pythonVersion)": #TestApp & {
-				"frameworkName": frameworkName
+			apps: "\(frameworkName)": "\(pythonVersion)": #PythonApp & {
+				source: bl.Directory & {
+					"source": env.assets
+					path: frameworkName
+				}
 				"pythonVersion": pythonVersion
 				description: "\(frameworkName) on python \(pythonVersion)"
 			}

--- a/config/python.cue
+++ b/config/python.cue
@@ -33,9 +33,9 @@ import (
 		\(strings.Join(["ENV \(k)=\(v)" for k, v in env], "\n"))
 
 		RUN mkdir -p \(app.dir)
-		COPY /flask/requirements.txt \(app.dir)/requirements.txt
+		COPY /requirements.txt \(app.dir)/requirements.txt
 		RUN pip install --no-cache-dir -r \(app.dir)/requirements.txt
-		ADD /flask/ \(app.dir)/
+		ADD / \(app.dir)/
 
 		ENV PORT=\(port)
 		EXPOSE \(port)


### PR DESCRIPTION
This fixes your config!

I simply removed the intermediary definition that inlines a task (#TestApp), this simplifies the config and does not trigger the bug on "source". Hard to understand the root cause, whether a bug on Cue or in the bl runtime. But it solves your issue in short term and removes some lines of code.

Also fixes the path in your Dockerfile that was hardcoded to /flask. Now the path is correct, the path should be '/'.